### PR TITLE
Use __construct method

### DIFF
--- a/includes/class.jetpack-user-agent.php
+++ b/includes/class.jetpack-user-agent.php
@@ -96,7 +96,7 @@ class Jetpack_User_Agent_Info {
 	);
 
    //The constructor. Initializes default variables.
-   function Jetpack_User_Agent_Info()
+   function __construct()
    {
    		if ( !empty( $_SERVER['HTTP_USER_AGENT'] ) )
        		$this->useragent = strtolower( $_SERVER['HTTP_USER_AGENT'] );


### PR DESCRIPTION
Methods that have the same name as the class they are defined in are deprecated, and will be removed in the future.