### PR TITLE
Address general PHP issues for 5.x upgrade preparation

### DIFF
--- a/includes/bu-mobile-support.php
+++ b/includes/bu-mobile-support.php
@@ -23,7 +23,7 @@ function bucc_is_mobile() {
 	}
 
 	// if we're on mobile css edit page, or looking at the frontend (while being mobile), then YES
-	if ( $_GET['page'] == 'editcss-mobile' || ( ! is_admin() && bu_mobile_wants_mobile() ) ) {
+	if ( ( isset( $_GET['page'] ) && $_GET['page'] === 'editcss-mobile' ) || ( ! is_admin() && bu_mobile_wants_mobile() ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
* Check if `$_GET['page']` is set to avoid an `undefined index` notice.